### PR TITLE
fix for maven multimodules projects with multiple source roots

### DIFF
--- a/src/ca/weblite/netbeans/mirah/lexer/MirahParser.java
+++ b/src/ca/weblite/netbeans/mirah/lexer/MirahParser.java
@@ -607,7 +607,7 @@ public class MirahParser extends Parser {
                 return root;
             }
         }
-        return null;
+        return ClassPath.getClassPath(file, ClassPath.SOURCE).findOwnerRoot(file);
     }
 
     @Override


### PR DESCRIPTION
There was an issue not finding root folder for mirah files for maven based projects with mirah locations like /src/main/mirah
